### PR TITLE
Adding minimal careers page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -108,7 +108,7 @@ const config = {
             label: 'Terminology',
           },
           {
-            to: '/careers',
+            href: 'https://risczero.rippling-ats.com',
             position: 'left',
             label: 'Careers',
           },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -108,6 +108,11 @@ const config = {
             label: 'Terminology',
           },
           {
+            to: '/careers',
+            position: 'left',
+            label: 'Careers',
+          },
+          {
             href: 'https://github.com/Risc0',
             label: 'GitHub',
             position: 'right',

--- a/src/pages/careers.md
+++ b/src/pages/careers.md
@@ -1,0 +1,6 @@
+---
+title: Careers
+---
+# Careers
+
+See our [current job listings](https://risczero.rippling-ats.com).


### PR DESCRIPTION
Ash and Chelsea pinged me about getting the ball rolling on getting a careers page up. 

Status: 
- would be nice to add a javascript widget to manage rippling job listings. Got security clearance from Mitchell. ran into technical confusion - see first attempt [here](https://github.com/risc0/website/tree/adding-careers). looped in rami to see about resolving technical confusion.
- this branch/PR offers an alternate route forward on landing a careers page that has a careers link rather than a careers widget. 
- could land as is as a minimal step forward; needs more text for polish. 