### PR TITLE
Adding jobs widget

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -108,7 +108,7 @@ const config = {
             label: 'Terminology',
           },
           {
-            href: 'https://risczero.rippling-ats.com',
+            to: '/careers',
             position: 'left',
             label: 'Careers',
           },

--- a/src/pages/careers.md
+++ b/src/pages/careers.md
@@ -1,6 +1,18 @@
 ---
 title: Careers
 ---
+<head>
+<link rel="stylesheet" type="text/css" media="all" href="https://assets.rippling-ats.com/stylesheets/embed.css" />
+<script type="text/javascript">
+		var ht_settings = ( ht_settings || new Object() );
+		ht_settings.site_url = "risczero";
+		// set this to true if you want jobs to open in a new window
+		ht_settings.open_jobs_in_new_tab = false;
+</script>
+
+<script src="https://assets.rippling-ats.com/javascripts/embed.js" type="text/javascript"></script>
+</head>
+
 # Careers
 
-See our [current job listings](https://risczero.rippling-ats.com).
+<div id="hiringthing-jobs"></div>


### PR DESCRIPTION
This PR includes our current job listings on an internal careers page (pages/careers.md) and updates the navbar link to point to that page. 