### PR TITLE
Adding "what is a trace"

### DIFF
--- a/docs/explainers/proof-system/proof-system-sequence-diagram.md
+++ b/docs/explainers/proof-system/proof-system-sequence-diagram.md
@@ -1,6 +1,10 @@
+---
+sidebar_position: 3
+---
+
 # The RISC Zero Proof System
 
-*RISC Zero offers a computational `receipt` for any code that runs within the RISC Zero zkVM, which serves to verifiably link the code that ran to the asserted output. RISC Zero's receipts are built on the shoulders of several recent advances in the world of Zero-Knowledge Cryptography: [zk-STARKs](https://eprint.iacr.org/2018/046.pdf), [PLONK](https://eprint.iacr.org/2019/953.pdf), and [DEEP-ALI](https://arxiv.org/pdf/1903.12243.pdf).*
+*RISC Zero offers a [computational receipt](what_is_a_receipt.md) for any code that runs within the [RISC Zero zkVM](../zkvm/what_is_risc_zero.md), which serves to verifiably link the code that ran to the asserted output. RISC Zero's receipts are built on the shoulders of several recent advances in the world of Zero-Knowledge Cryptography: [zk-STARKs](https://eprint.iacr.org/2018/046.pdf), [PLONK](https://eprint.iacr.org/2019/953.pdf), and [DEEP-ALI](https://arxiv.org/pdf/1903.12243.pdf).*
 
 *In this document, we present a succinct introduction to the RISC Zero Proof system, including a sequence diagram and a step-by-step description of the RISC Zero Non-Interactive Argument of Knowledge. We encourage readers to follow along with the [Fibonacci Trace Example](https://docs.google.com/spreadsheets/d/1Onr41OozD62y-B0jIL7bHAH5kf771-o4xvmnHUFpOyo/edit?usp=sharing) for a more concrete description of the protocol.*
 
@@ -26,7 +30,7 @@ sequenceDiagram
 ## The RISC Zero Proof System: A Step-By-Step Description
 
 ### The Structure of the Execution Trace
-- The Prover runs a computation in order to generate an `Execution Trace`. 
+- The Prover runs a computation in order to generate an [`Execution Trace`](what_is_a_trace.md). 
   - The `trace` is organized into `columns,` and the columns are categorized as `control columns`, `data columns`, and `PLONK columns`.
     - The `control columns` handle system initialization and shutdown, the initial program code to load into memory before execution, and other control signals that don't depend on the program execution.
     - The `data columns` contain the input and the computation data, both of which are private. These columns are committed in two orderings: 

--- a/docs/explainers/proof-system/what_is_a_trace.md
+++ b/docs/explainers/proof-system/what_is_a_trace.md
@@ -1,0 +1,13 @@
+---
+sidebar_position: 2
+---
+
+# What is an Execution Trace? 
+
+When a piece of code runs on a machine, the **execution trace** is a complete record of the computation: a snapshot of the full state of the machine at each clock cycle of the computation. 
+
+It's typical to write an execution trace as a rectangular array, where each row shows the complete state of the machine at a given moment in time, and each column shows a temporal record of some particular aspect of the computation (say, the value stored in a particular RISC-V register) at each clock cycle. A line-by-line analysis of the trace allows for a computational audit with respect to the program instructions and the underlying computer architecture. 
+
+`RISC Zero's computational receipts use cutting-edge technology to audit an execution trace while preserving computational privacy.`
+
+*For more information about the process of turning an execution trace into a computational receipt, see the [Proof System Sequence Diagram](proof-system-sequence-diagram.md), the [Fibonacci Trace Validation Example](https://docs.google.com/spreadsheets/d/e/2PACX-1vSJ1J5PcS2op_vrGtbK5Mif0gAN6wbAaTSWTHy2vuFtfbtqbI_dRqpalNamNjjUcyqD7hDPJRgI2cG-/pubhtml#) and the [STARKs reference page](../../reference-docs/about-starks.md).* 


### PR DESCRIPTION
- Adding a new document called `What is an Execution Trace?` to live under `About the Proof System` after `What is a receipt` and before the `sequence diagram.` 


- Also added a couple links to the sequence diagram to point toward "what is a receipt," and "what is a trace," and "what is [zkVM]"