### PR TITLE
making risczero.com/careers functional

### DIFF
--- a/src/pages/careers.md
+++ b/src/pages/careers.md
@@ -1,11 +1,6 @@
 ---
 title: Careers
 ---
-<head>
-<meta name="description" content="View job descriptions, salary ranges, and further information about career opportunities at RISC Zero."/>
-<meta property="og:description" content="View job descriptions, salary ranges, and further information about career opportunities at RISC Zero."/>
-</head>
 
 # Careers
-<div id="grnhse_app"></div>
-<script src="https://boards.greenhouse.io/embed/job_board/js?for=risczero" async defer></script>
+See our current openings at https://boards.greenhouse.io/risczero


### PR DESCRIPTION
www.risczero.com/careers is not loading content. 

This PR updates risczero.com/careers with a simple link to the Greenhouse jobs page