### PR TITLE
Updating links

### DIFF
--- a/docs/explainers/proof-system/constructing-a-seal.md
+++ b/docs/explainers/proof-system/constructing-a-seal.md
@@ -8,7 +8,7 @@ sidebar_position: 3
 
 The construction of a seal is highly technical, relying on several recent advances in the world of zero-knowledge cryptography. In this series of 10 brief lessons, we walk through the construction of a RISC Zero seal with as little technical jargon as possible. 
 
-You can peek behind the formulas on the [Google Sheet version](https://docs.google.com/spreadsheets/d/1Onr41OozD62y-B0jIL7bHAH5kf771-o4xvmnHUFpOyo/edit?usp=sharing) or [download a PDF](assets/fibonacci-stark.pdf). If you make sense of these 10 lessons, you'll have a solid handle on the mechanics of a zk-STARK (and we'd likely love to [hire you](../src/pages/careers.md)). 
+You can peek behind the formulas on the [Google Sheet version](https://docs.google.com/spreadsheets/d/1Onr41OozD62y-B0jIL7bHAH5kf771-o4xvmnHUFpOyo/edit?usp=sharing) or [download a PDF](assets/fibonacci-stark.pdf). If you make sense of these 10 lessons, you'll have a solid handle on the mechanics of a zk-STARK (and we'd likely love to [hire you](../../../src/pages/careers.md). 
 
 The [proof system sequence diagram](proof-system-sequence-diagram.md) describes this process in more generality; we suggest going back and forth between this document and the sequence diagram. 
 

--- a/docs/explainers/proof-system/constructing-a-seal.md
+++ b/docs/explainers/proof-system/constructing-a-seal.md
@@ -8,7 +8,7 @@ sidebar_position: 3
 
 The construction of a seal is highly technical, relying on several recent advances in the world of zero-knowledge cryptography. In this series of 10 brief lessons, we walk through the construction of a RISC Zero seal with as little technical jargon as possible. 
 
-You can peek behind the formulas on the [Google Sheet version](https://docs.google.com/spreadsheets/d/1Onr41OozD62y-B0jIL7bHAH5kf771-o4xvmnHUFpOyo/edit?usp=sharing) or [download a PDF](assets/fibonacci-stark.pdf). If you make sense of these 10 lessons, you'll have a solid handle on the mechanics of a zk-STARK (and we'd likely love to [hire you](../../../careers).
+You can peek behind the formulas on the [Google Sheet version](https://docs.google.com/spreadsheets/d/1Onr41OozD62y-B0jIL7bHAH5kf771-o4xvmnHUFpOyo/edit?usp=sharing) or [download a PDF](assets/fibonacci-stark.pdf). If you make sense of these 10 lessons, you'll have a solid handle on the mechanics of a zk-STARK (and we'd likely love to [hire you](../../../careers)).
 
 The [proof system sequence diagram](proof-system-sequence-diagram.md) describes this process in more generality; we suggest going back and forth between this document and the sequence diagram. 
 

--- a/docs/explainers/proof-system/constructing-a-seal.md
+++ b/docs/explainers/proof-system/constructing-a-seal.md
@@ -8,7 +8,7 @@ sidebar_position: 3
 
 The construction of a seal is highly technical, relying on several recent advances in the world of zero-knowledge cryptography. In this series of 10 brief lessons, we walk through the construction of a RISC Zero seal with as little technical jargon as possible. 
 
-You can peek behind the formulas on the [Google Sheet version](https://docs.google.com/spreadsheets/d/1Onr41OozD62y-B0jIL7bHAH5kf771-o4xvmnHUFpOyo/edit?usp=sharing) or [download a PDF](assets/fibonacci-stark.pdf). If you make sense of these 10 lessons, you'll have a solid handle on the mechanics of a zk-STARK (and we'd likely love to [hire you](../../../src/pages/careers.md). 
+You can peek behind the formulas on the [Google Sheet version](https://docs.google.com/spreadsheets/d/1Onr41OozD62y-B0jIL7bHAH5kf771-o4xvmnHUFpOyo/edit?usp=sharing) or [download a PDF](assets/fibonacci-stark.pdf). If you make sense of these 10 lessons, you'll have a solid handle on the mechanics of a zk-STARK (and we'd likely love to [hire you](../../../careers).
 
 The [proof system sequence diagram](proof-system-sequence-diagram.md) describes this process in more generality; we suggest going back and forth between this document and the sequence diagram. 
 

--- a/docs/explainers/proof-system/what_is_a_receipt.md
+++ b/docs/explainers/proof-system/what_is_a_receipt.md
@@ -10,5 +10,5 @@ The receipt serves as a cryptographic authentication that the given method was e
 
 By linking the MethodID to the asserted output of the computation, computational receipts offer a powerful new model for trust in software. The option to check a computational receipt opens the doors to the `era of verifiable computing`, where we use mathematics and science to bring trustable software into trustless environments. 
 
-*For more information about RISC Zero's receipts, see the [Proof System Sequence Diagram](proof-system-sequence-diagram.md), the [Fibonacci Trace Validation Example](https://docs.google.com/spreadsheets/d/e/2PACX-1vSJ1J5PcS2op_vrGtbK5Mif0gAN6wbAaTSWTHy2vuFtfbtqbI_dRqpalNamNjjUcyqD7hDPJRgI2cG-/pubhtml#) and the [STARKs reference page](../../reference-docs/about-starks.md).* 
+*For a more technical description of RISC Zero's receipts, see the [Proof System Sequence Diagram](proof-system-sequence-diagram.md), the [Seal Construction Explainer](constructing-a-seal.md) and the [STARKs reference page](../../reference-docs/about-starks.md).* 
 

--- a/docs/explainers/proof-system/what_is_a_trace.md
+++ b/docs/explainers/proof-system/what_is_a_trace.md
@@ -10,4 +10,4 @@ It's typical to write an execution trace as a rectangular array, where each row 
 
 `RISC Zero's computational receipts use cutting-edge technology to audit an execution trace while preserving computational privacy.`
 
-*For more technical description of the process of creating a computational receipt, see the [proof system sequence diagram](proof-system-sequence-diagram.md), the [seal construction explainer](https://docs.google.com/spreadsheets/d/e/2PACX-1vSJ1J5PcS2op_vrGtbK5Mif0gAN6wbAaTSWTHy2vuFtfbtqbI_dRqpalNamNjjUcyqD7hDPJRgI2cG-/pubhtml#) and the [STARKs reference page](../../reference-docs/about-starks.md).* 
+*For more technical description of the process of creating a computational receipt, see the [proof system sequence diagram](proof-system-sequence-diagram.md), the [seal construction explainer](constructing-a-seal.md) and the [STARKs reference page](../../reference-docs/about-starks.md).* 

--- a/docs/explainers/proof-system/what_is_a_trace.md
+++ b/docs/explainers/proof-system/what_is_a_trace.md
@@ -10,4 +10,4 @@ It's typical to write an execution trace as a rectangular array, where each row 
 
 `RISC Zero's computational receipts use cutting-edge technology to audit an execution trace while preserving computational privacy.`
 
-*For more information about the process of turning an execution trace into a computational receipt, see the [Proof System Sequence Diagram](proof-system-sequence-diagram.md), the [Fibonacci Trace Validation Example](https://docs.google.com/spreadsheets/d/e/2PACX-1vSJ1J5PcS2op_vrGtbK5Mif0gAN6wbAaTSWTHy2vuFtfbtqbI_dRqpalNamNjjUcyqD7hDPJRgI2cG-/pubhtml#) and the [STARKs reference page](../../reference-docs/about-starks.md).* 
+*For more technical description of the process of creating a computational receipt, see the [proof system sequence diagram](proof-system-sequence-diagram.md), the [seal construction explainer](https://docs.google.com/spreadsheets/d/e/2PACX-1vSJ1J5PcS2op_vrGtbK5Mif0gAN6wbAaTSWTHy2vuFtfbtqbI_dRqpalNamNjjUcyqD7hDPJRgI2cG-/pubhtml#) and the [STARKs reference page](../../reference-docs/about-starks.md).* 

--- a/docs/reference-docs/about-finite-fields.md
+++ b/docs/reference-docs/about-finite-fields.md
@@ -1,5 +1,5 @@
 # About Finite Fields 
-*RISC Zero's [computational receipts](../explainers/proof-system/what_is_a_receipt.md) are built by converting an assertion of computational integrity into an assertion about polynomials over finite fields. This document serves as a minimal introduction to finite fields, targeted at folks who have some exposure to modular arithmetic and who are curious to learn more about the [math and cryptography behind RISC Zero](https://docs.google.com/spreadsheets/d/e/2PACX-1vSJ1J5PcS2op_vrGtbK5Mif0gAN6wbAaTSWTHy2vuFtfbtqbI_dRqpalNamNjjUcyqD7hDPJRgI2cG-/pubhtml#).*  
+*RISC Zero's [computational receipts](../explainers/proof-system/what_is_a_receipt.md) are built by converting an assertion of computational integrity into an assertion about polynomials over finite fields. This document serves as a minimal introduction to finite fields, targeted at folks who have some exposure to modular arithmetic and who are curious to learn more about the [math and cryptography behind RISC Zero](../explainers/proof-system/constructing-a-seal.md).*  
 
 ## Finite Fields 101: Reciprocals, Exponents, and Generators
 Loosely speaking, a **field** is a set of elements for which addition, subtraction, multiplication, and division work cleanly.  

--- a/docs/reference-docs/about-starks.md
+++ b/docs/reference-docs/about-starks.md
@@ -1,15 +1,15 @@
 # About STARKs
 
-The **seal** on a RISC Zero receipt is generated using a zk-STARK: a *zero knowledge, scalable, transparent argument of knowledge.* 
+The seal on a RISC Zero receipt is generated using a **zk-STARK**: a *zero knowledge, scalable, transparent argument of knowledge.* 
 
 STARKs are a highly technical process - an innovation in the world of zero-knowledge cryptography introduced by Eli Ben-Sasson et. al in 2018. In order to prove the integrity of a computation with a STARK, the prover arithmetizes the entire question. By encoding the [execution trace](../explainers/proof-system/what_is_a_trace.md) into [polynomials](about-finite-fields.md), the statement of computational integrity is reduced to a statement about polynomial division. 
 
 ## Documentation
 
 In the context of the RISC Zero zkVM, the term **seal** refers to the zk-STARK that attests to the integrity of the trace. The following documentation describes the RISC Zero zk-STARK in more detail: 
-- [Proof system sequence diagram](proof-system-sequence-diagram.md) <br/> This document includes a sequence diagram and step-by-step specification of the RISC Zero zk-STARK.
+- [Proof system sequence diagram](../explainers/proof-system/proof-system-sequence-diagram.md) <br/> This document includes a sequence diagram and step-by-step specification of the RISC Zero zk-STARK.
   
-- [Constructing a seal](constructing-a-seal.md) <br/> This document shows a simplified, concrete example of the construction of a RISC Zero seal. 
+- [Constructing a seal](../explainers/proof-system/constructing-a-seal.md) <br/> This document shows a simplified, concrete example of the construction of a RISC Zero seal. 
 
 ## References
 We recommend the following external references on STARKs:

--- a/docs/reference-docs/about-starks.md
+++ b/docs/reference-docs/about-starks.md
@@ -1,12 +1,15 @@
 # About STARKs
 
-RISC Zero's receipts are generated using a zk-STARK: a *zero knowledge, scalable, transparent argument of knowledge.* 
+The **seal** on a RISC Zero receipt is generated using a zk-STARK: a *zero knowledge, scalable, transparent argument of knowledge.* 
 
-STARKs are a highly technical process - an innovation in the world of zero-knowledge cryptography introduced by Eli Ben-Sasson et. al in 2018. In order to prove the integrity of a computation with a STARK, the prover arithmetizes the entire question. By encoding the execution trace into polynomials, the statement of computational integrity is reduced to a statement about polynomial division. 
+STARKs are a highly technical process - an innovation in the world of zero-knowledge cryptography introduced by Eli Ben-Sasson et. al in 2018. In order to prove the integrity of a computation with a STARK, the prover arithmetizes the entire question. By encoding the [execution trace](../explainers/proof-system/what_is_a_trace.md) into [polynomials](about-finite-fields.md), the statement of computational integrity is reduced to a statement about polynomial division. 
 
 ## Documentation
 
-To get started in making sense of the RISC Zero STARK, start with the [RISC Zero Proof System Sequence Diagram + IOP Description](../explainers/proof-system/proof-system-sequence-diagram.md) and the [Fibonacci Trace Validation](https://docs.google.com/spreadsheets/d/e/2PACX-1vSJ1J5PcS2op_vrGtbK5Mif0gAN6wbAaTSWTHy2vuFtfbtqbI_dRqpalNamNjjUcyqD7hDPJRgI2cG-/pubhtml#) example. 
+In the context of the RISC Zero zkVM, the term **seal** refers to the zk-STARK that attests to the integrity of the trace. The following documentation describes the RISC Zero zk-STARK in more detail: 
+- [Proof system sequence diagram](proof-system-sequence-diagram.md) <br/> This document includes a sequence diagram and step-by-step specification of the RISC Zero zk-STARK.
+  
+- [Constructing a seal](constructing-a-seal.md) <br/> This document shows a simplified, concrete example of the construction of a RISC Zero seal. 
 
 ## References
 We recommend the following external references on STARKs:


### PR DESCRIPTION
Previously, there were a number of links on the page pointing to the (externally hosted) `fibonacci spreadsheet explainer doc`. 
Now, those links point to the (internally hosted) `constructing a seal` markdown explainer. 

Also some minor copy editing on `About STARKs` 