### PR TITLE
adding mermaid to blog

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -30,6 +30,8 @@ const config = {
           editUrl: 'https://github.com/risc0/website/edit/main/',
         },
         blog: {
+          remarkPlugins: [math, require('mdx-mermaid')],
+          rehypePlugins: [katex],
           showReadingTime: true,
           // Please change this to your repo.
           editUrl: 'https://github.com/risc0/website/edit/main/',


### PR DESCRIPTION
This PR adds support for mermaid and katex in `blog`. 
Resolves #41 