### PR TITLE
fixing careers link and typo

### DIFF
--- a/blog/2022-07-11-cso/index.md
+++ b/blog/2022-07-11-cso/index.md
@@ -24,9 +24,9 @@ I have often said that I think I will probably spend the rest of my career tryin
 
 If you are interested in joining us, check out our careers page here: 
 
-* https://boards.greenhouse.io/risczero
+* https://jobs.lever.co/risczero.com
 
-If you want to learn more about how Zero Knowlege works, here are some resources: 
+If you want to learn more about how ZKPs work, here are some resources: 
 
 * https://www.youtube.com/watch?v=fOGdb1CTu5c&t=683s
 * https://blog.chain.link/what-is-a-zero-knowledge-proof-zkp/

--- a/blog/2022-07-11-cso/index.md
+++ b/blog/2022-07-11-cso/index.md
@@ -26,7 +26,7 @@ If you are interested in joining us, check out our careers page here:
 
 * https://jobs.lever.co/risczero.com
 
-If you want to learn more about how ZKPs work, here are some resources: 
+If you want to learn more about how zero knowledge works, here are some resources: 
 
 * https://www.youtube.com/watch?v=fOGdb1CTu5c&t=683s
 * https://blog.chain.link/what-is-a-zero-knowledge-proof-zkp/

--- a/blog/2022-07-11-cso/index.md
+++ b/blog/2022-07-11-cso/index.md
@@ -26,7 +26,7 @@ If you are interested in joining us, check out our careers page here:
 
 * https://jobs.lever.co/risczero.com
 
-If you want to learn more about how zero knowledge works, here are some resources: 
+If you want to learn more about how Zero Knowledge works, here are some resources: 
 
 * https://www.youtube.com/watch?v=fOGdb1CTu5c&t=683s
 * https://blog.chain.link/what-is-a-zero-knowledge-proof-zkp/


### PR DESCRIPTION
The broken link checker surfaced the fact that one of our blog posts was pointing to an out-of-date careers page. 

This PR fixes that link and a minor typo that I noticed along the way. 