### PR TITLE
Arrows in graphs are visible in Dark Mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -42,3 +42,7 @@
 [data-theme='dark'] .mermaid .messageLine0, .messageLine1 {
       filter: invert(51%) sepia(84%) saturate(405%) hue-rotate(21deg) brightness(94%) contrast(91%) !important;
 }
+/* NOTE Must be a separate specification from the above or it won't toggle off */
+[data-theme='dark'] .mermaid .flowchart-link {
+      filter: invert(51%) sepia(84%) saturate(405%) hue-rotate(21deg) brightness(94%) contrast(91%) !important;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -37,3 +37,8 @@
 [data-theme='dark'] .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.3);
 }
+
+/* Mermaid elements must be changed to be visible in dark mode */
+[data-theme='dark'] .mermaid .messageLine0, .messageLine1 {
+      filter: invert(51%) sepia(84%) saturate(405%) hue-rotate(21deg) brightness(94%) contrast(91%) !important;
+}


### PR DESCRIPTION
Arrows in graphs appear as a noticeable yellow color when the website is in dark mode, instead of being a grey color that blends in with the background.